### PR TITLE
Update segment-engine.js

### DIFF
--- a/src/engines/segment-engine.js
+++ b/src/engines/segment-engine.js
@@ -187,6 +187,18 @@ export default class SegmentEngine extends AudioTimeEngine {
     this.releaseRel = optOrDef(options.releaseRel, 0);
 
     /**
+    * Fading volume relase time in seconds when new segment triggers on top of previous one.
+    * @type {Number}
+    */
+    this.polyCutoff = optOrDef(options.polyCutoff, 2);
+
+    /**
+    * End volume of previous segment at the end of fade release time.
+    * @type {Number}
+    */
+    this.polyEndvol = optOrDef(options.polyEndvol, 0);
+
+    /**
      * Segment resampling in cent
      * @type {Number}
      */
@@ -341,6 +353,15 @@ export default class SegmentEngine extends AudioTimeEngine {
     var segmentPeriod = this.periodAbs;
     var segmentIndex = this.segmentIndex;
 
+      // fade out previous segment on new segment trigger
+      if (this.prevGain) {
+          // cancel previous faders, i.e. releaseAbs, releaseRel that might interfere and cause clicks
+          // when adding another fader.
+          this.prevGain.gain.cancelScheduledValues(time);
+          // fade out previous segment...
+          this.prevGain.gain.setTargetAtTime(this.polyEndvol, audioContext.currentTime, this.polyCutoff);
+      }
+
     if (this.buffer) {
       var segmentPosition = 0.0;
       var segmentDuration = 0.0;
@@ -445,7 +466,9 @@ export default class SegmentEngine extends AudioTimeEngine {
       // make segment
       if (this.gain > 0 && segmentDuration > 0) {
         // make segment envelope
-        var envelope = audioContext.createGain();
+        this.prevGain = audioContext.createGain();
+        var envelope = this.prevGain;
+
         var attack = this.attackAbs + this.attackRel * segmentDuration;
         var release = this.releaseAbs + this.releaseRel * segmentDuration;
 
@@ -463,7 +486,7 @@ export default class SegmentEngine extends AudioTimeEngine {
         envelope.gain.setValueAtTime(0.0, segmentTime);
         envelope.gain.linearRampToValueAtTime(this.gain, attackEndTime);
 
-        if (releaseStartTime > attackEndTime)
+        //if (releaseStartTime > attackEndTime)
           envelope.gain.setValueAtTime(this.gain, releaseStartTime);
 
         envelope.gain.linearRampToValueAtTime(0.0, segmentEndTime);


### PR DESCRIPTION
Same as #4, but added cancelScheduledValues when fading out previous segment so releaseAbs/releaseRel don't interfere.
